### PR TITLE
fix: Change tag and release workflow activation to be manual

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -1,8 +1,6 @@
 name: Bump version
 on:
-  push:
-    branches:
-      - master
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## Description

No changelog is created for master branch. On further analysis, it doesn't make sense for this project to have a release on every PR merge as of now. Hence, changing this to manual dispatch.

Closes #11 