### PR TITLE
feat(extension): Remove configurability of recommended settings file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,3 @@ Keep a file named `recommended-settings.json` in your repository containing the 
 Team members can load these setttings by activating the command "Load Project Recommended Settings".
 
 ![image](https://github.com/user-attachments/assets/ab50429d-b352-43be-89e1-262832730550)
-
-## Extension Settings
-
-This extension contributes the following settings:
-
-| Setting                                          | Type     | Default                     | Value Description                                                                               |
-| ------------------------------------------------ | -------- | --------------------------- | ----------------------------------------------------------------------------------------------- |
-| `recommended-settings.recommended-settings-file` | `string` | `recommended-settings.json` | Name of recommended settings file to load settings from. File should be under `.vscode` folder. |

--- a/package.json
+++ b/package.json
@@ -22,18 +22,7 @@
         "command": "recommended-settings.load-recommended-settings",
         "title": "Load Project Recommended Settings"
       }
-    ],
-    "configuration": {
-      "title": "Project Recommended Settings",
-      "properties": {
-        "recommended-settings.recommended-settings-file": {
-          "type": "string",
-          "default": "recommended-settings.json",
-          "pattern": "^[\\w-]+\\.json$",
-          "markdownDescription": "Name of recommended settings file to load settings from. File should be under `.vscode` folder."
-        }
-      }
-    }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "pnpm run build",

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -1,5 +1,5 @@
 import { equal, ok } from "assert";
-import { fake, reset, restore, spy, stub, type SinonSpy } from "sinon";
+import { fake, reset, spy, stub, type SinonSpy } from "sinon";
 import {
   commands,
   extensions,
@@ -8,10 +8,17 @@ import {
   window,
   workspace,
   type TextDocument,
-  type WorkspaceConfiguration,
 } from "vscode";
 
 suite("Extension Test Suite", () => {
+  let informationMessageSpy: SinonSpy;
+  let errorMessageSpy: SinonSpy;
+
+  suiteSetup(() => {
+    informationMessageSpy = spy(window, "showInformationMessage");
+    errorMessageSpy = spy(window, "showErrorMessage");
+  });
+
   suite("Activation", () => {
     test("Extension should activate", async () => {
       const extension = extensions.getExtension("ragavks.recommended-settings");
@@ -25,9 +32,6 @@ suite("Extension Test Suite", () => {
   });
 
   suite("'Load Project Recommended Settings' command", () => {
-    let informationMessageSpy: SinonSpy;
-    let errorMessageSpy: SinonSpy;
-
     suiteSetup(async () => {
       const extension = extensions.getExtension(
         "ragavks.recommended-settings"
@@ -36,14 +40,8 @@ suite("Extension Test Suite", () => {
       await extension.activate();
     });
 
-    setup(() => {
-      informationMessageSpy = spy(window, "showInformationMessage");
-      errorMessageSpy = spy(window, "showErrorMessage");
-    });
-
     teardown(() => {
       reset();
-      restore();
     });
 
     test("command should be registered", async () => {
@@ -52,27 +50,6 @@ suite("Extension Test Suite", () => {
       ok(
         registeredCommands.includes(
           "recommended-settings.load-recommended-settings"
-        )
-      );
-    });
-
-    test("Command should fail if `recommended-settings.recommended-settings-file` setting is misconfigured", async () => {
-      // setup stubs
-      stub(workspace, "getConfiguration")
-        .withArgs("recommended-settings")
-        .returns({
-          get: stub().withArgs("recommended-settings-file").returns(undefined),
-        } as unknown as WorkspaceConfiguration);
-
-      // trigger
-      await commands.executeCommand(
-        "recommended-settings.load-recommended-settings"
-      );
-
-      // assert
-      ok(
-        errorMessageSpy.calledOnceWith(
-          "`recommended-settings.recommended-settings-file` setting is misconfigured."
         )
       );
     });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,16 +14,7 @@ export function activate(context: ExtensionContext) {
   const disposable = commands.registerCommand(
     "recommended-settings.load-recommended-settings",
     async () => {
-      const filename: string | undefined = workspace
-        .getConfiguration("recommended-settings")
-        .get("recommended-settings-file");
-
-      if (!filename) {
-        window.showErrorMessage(
-          "`recommended-settings.recommended-settings-file` setting is misconfigured."
-        );
-        return;
-      }
+      const filename = "recommended-settings.json";
 
       if (!workspace.workspaceFolders) {
         window.showErrorMessage("Cannot be run outside of a workspace.");


### PR DESCRIPTION
## Description

This reverts changes from #29 and #25. 

Since, this is not a high priority feature and it is impedes development of other more useful features. Rolling this back, but will look to add this feature back in future.

Closes #30.

BREAKING CHANGE: Recommended settings file name is no longer configurable.
